### PR TITLE
Fix duplicate user code

### DIFF
--- a/apps/api/src/scim.ts
+++ b/apps/api/src/scim.ts
@@ -65,7 +65,8 @@ scimRoute.post('/Users', passport.authenticate('bearer'), async (req, res) => {
     // Set displayName to name 
     const name = displayName;
   
-    // Check if the User exists in the database 
+    // Check if the User exists in the database
+    // externalId + orgId = user uniqueness per SCIM RFC Section 3.3 
     const duplicateUser = await prisma.user.findFirst({
         select: {
           id: true,
@@ -73,7 +74,7 @@ scimRoute.post('/Users', passport.authenticate('bearer'), async (req, res) => {
           name: true,
         },
         where: {
-          email,
+          externalId,
           org: {id: ORG_ID}
         }
       });


### PR DESCRIPTION
To satisfy the uniqueness requirement (per https://www.rfc-editor.org/rfc/rfc7644#section-3.3) for a duplicate user, I changed the email parameter to externalId under the server's database lookup code to check for a duplicate user. Both externalId + orgId makes a user in this database unique. Will also make changes in the SCIM blog to reflect this, and I'll also explain. 